### PR TITLE
Add new tiny stack id

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -18,3 +18,6 @@ id = "io.buildpacks.stacks.bionic"
 
 [[stacks]]
 id = "org.cloudfoundry.stacks.tiny"
+
+[[stacks]]
+id = "io.paketo.stacks.tiny"


### PR DESCRIPTION
In preparation for renaming the tiny stack to `io.paketo.stacks.tiny`, we first want all Go language family CNB's to support the current tiny stack id as well as the new one. This way we will not break anyone during the transition. This PR adds the new stack id to the buildpack.toml.

Releng tracker story for reference: https://www.pivotaltracker.com/story/show/172902979